### PR TITLE
Fix #1

### DIFF
--- a/notebook-drawing/main.js
+++ b/notebook-drawing/main.js
@@ -32,9 +32,9 @@ define([
     }
 
     function updateCellContents(cell, context) {
-        let text =
-            `Annotations created with the [notebook-drawing extension](https://github.com/nicknytko/notebook-drawing):
-<img src="${context.getCanvasData()}"/>`;
+        let extension_url = "https://github.com/nicknytko/notebook-drawing"
+        let description = "Drawing created with the notebook-drawing extension (github.com/nicknytko/notebook-drawing)"
+        let text =`<img src="${context.getCanvasData()}" title="${description}. Install the extension to edit." alt="${description}"/>`;
         cell.set_text(text);
         /*cell.execute();*/
     }
@@ -43,7 +43,7 @@ define([
         cells.forEach(cell => {
             if (cell.metadata.drawing_enabled) {
                 let text = cell.get_text();
-                let contents = text.split("\"")[1];
+                let contents = text.split("\"")[1]; // this seems fragile, but I don't know of a better way
                 setupCell(cell, contents);
             }
         });

--- a/notebook-drawing/main.js
+++ b/notebook-drawing/main.js
@@ -27,16 +27,14 @@ define([
     }
     
     function insertCell() {
-        let cell = Jupyter.notebook.insert_cell_below("code");
+        let cell = Jupyter.notebook.insert_cell_below("markdown");
         setupCell(cell);
     }
 
     function updateCellContents(cell, context) {
         let text =
-            `## This cell has annotations, run it with Ctrl+Enter to see them. ##
-## Or, download the notebook extension from (https://github.com/nicknytko/notebook-drawing) to view automatically. ##
-from IPython.display import Image
-Image(url="${context.getCanvasData()}")`;
+            `Annotations created with the [notebook-drawing extension](https://github.com/nicknytko/notebook-drawing):
+<img src="${context.getCanvasData()}"/>`;
         cell.set_text(text);
         /*cell.execute();*/
     }

--- a/notebook-drawing/main.js
+++ b/notebook-drawing/main.js
@@ -32,7 +32,6 @@ define([
     }
 
     function updateCellContents(cell, context) {
-        let extension_url = "https://github.com/nicknytko/notebook-drawing"
         let description = "Drawing created with the notebook-drawing extension (github.com/nicknytko/notebook-drawing)"
         let text =`<img src="${context.getCanvasData()}" title="${description}. Install the extension to edit." alt="${description}"/>`;
         cell.set_text(text);


### PR DESCRIPTION
This changes the following behavior to fix #1:

When the extension is not installed, the default cell is a markdown cell with the image embedded rather than a python code cell.

This has a few advantages:
1. It can be used more seemlessly with other languages like Julia
2. It allows easy printing with the image in tact